### PR TITLE
Bump octia to clojure 1.8.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,13 +2,15 @@
   :description "A clojure library on top of compojure/ring to easily define api endpoints.
   Supports iodocs generation."
   :url "http://github.com/obohrer/octia"
-  :dependencies [[org.clojure/clojure       "1.5.1"]
-                 [compojure                 "1.1.6"
+  :dependencies [[org.clojure/clojure       "1.8.0"]
+                 [compojure                 "1.4.0"
                   :exclusions [joda-time]]
-                 [cheshire                  "5.3.1"]
+                 [cheshire                  "5.5.0"]
                  [com.palletops/thread-expr "1.3.0"]]
-  :warn-on-reflection true
+  :pedantic? :abort
+  :global-vars {*warn-on-reflection* true}
   :profiles {:dev
-             {:dependencies [[ring-mock "0.1.5"]
-			     [javax.servlet/servlet-api "2.5"]
-                             [midje     "1.6.3"]]}})
+             {:dependencies [[ring-mock                 "0.1.5"]
+                             [javax.servlet/servlet-api "2.5"]
+                             [midje                     "1.8.3"
+                              :exclusions [[commons-codec]]]]}})

--- a/test/octia/wrappers_test.clj
+++ b/test/octia/wrappers_test.clj
@@ -54,6 +54,6 @@
 (deftest json-both
   (fact "json is deserialized and serialized"
         (let [resp (request "/json/both" (cheshire/generate-string {:a "b" :c "d"}) "application/json")]
-          (:body resp) => "{\"c\":\"D\",\"a\":\"B\"}"
+          (:body resp) => "{\"a\":\"B\",\"c\":\"D\"}"
           (:headers resp) => {"Content-Type" "application/json; charset=UTF-8"})))
 


### PR DESCRIPTION
Also upgrade compojure and cheshire.

:pedantic added so that the build fails if dependencies does not converge.

Fixed :warn-on-reflection, moved inside :global-vars as it's the new way to go with recent leiningen versions.