### PR TITLE
Fix wrap-json-body wrapper

### DIFF
--- a/src/octia/wrappers.clj
+++ b/src/octia/wrappers.clj
@@ -1,6 +1,8 @@
 (ns octia.wrappers
   (:require [cheshire.core :as cheshire]
-            [pallet.thread-expr :refer [when-not->]]))
+            [pallet.thread-expr :refer [when-not->]]
+            [ring.util.request :as request])
+  (:import (java.io InputStream)))
 
 (defn wrap-json-output
   "convert the body of a response into json and add appropriate headers"
@@ -8,21 +10,20 @@
   (fn [request]
     (let [resp (handler request)]
       (-> resp
-          (when-not-> (instance? java.io.InputStream (:body resp))
+          (when-not-> (instance? InputStream (:body resp))
                       (update-in [:body] cheshire/generate-string)
                       (update-in [:headers] #(merge % {"Content-Type" "application/json; charset=UTF-8"})))))))
 
 (defn- json-request?
   [req]
-  (if-let [#^String type (:content-type req)]
+  (if-let [type (request/content-type req)]
     (not (empty? (re-find #"^application/(vnd.+)?json" type)))))
 
 (defn wrap-json-body
   [handler]
   (fn [req]
-    (if-let [body (and (json-request? req) (:body req))]
-      (let [bstr (slurp body)
-            json-body (cheshire/parse-string bstr true)
+    (if-let [body (and (json-request? req) (request/body-string req))]
+      (let [json-body (cheshire/parse-string body true)
             req* (assoc req :json-body json-body)]
         (handler req*))
       (handler req))))


### PR DESCRIPTION
Since ring 1.3.0, :content-type property is not available anymore (see https://github.com/ring-clojure/ring/blob/master/HISTORY.md#130-2014-06-02). Instead, it needs to be replaced by request/content-type function.
